### PR TITLE
未入力の人がいる場合の判定を判定モジュールに追加 #135

### DIFF
--- a/src/judge.js
+++ b/src/judge.js
@@ -1,9 +1,11 @@
+// 引き分けの判定を格納する関数
 const drawer = (playerList) => {
     for (let player of playerList) {
         player.judge = 0;
     }
 };
 
+// 勝ち負けの判定を格納する関数
 const winnerAndLoser = (playerList, judgeValue) => {
     const winHand = { 3: 0, 5: 2, 6: 1 }  // 判定と勝ち手を関連付けるオブジェクト
 
@@ -16,13 +18,28 @@ const winnerAndLoser = (playerList, judgeValue) => {
     }
 };
 
+// 未入力の人がいる時に判定を格納する関数
+const notHand = (playerList) => {
+    for (let player of playerList) {
+        if (player.hand == -1) {
+            player.judge = -1;
+        } else {
+            player.judge = 1;
+        }
+    }
+};
+
+// じゃんけん判定の本体 player.handの値は、グー:0 チョキ:1 パー:2 未入力:-1 とする
 module.exports = (playerList) => {
     let judgeValue = 0;
     const draw = [1, 2, 4, 7];  // 引き分けの判定を格納する配列
 
     for (const player of playerList) {
-        if (judgeValue == 7) { break; }
-        judgeValue |= 1 << player.hand;
+        if (player.hand == -1) {  // 未入力の人がいる場合その人以外が勝ち
+            notHand(playerList);
+            return playerList;
+        }
+        judgeValue |= 1 << player.hand;  // 2進数でどの手を出した人がいるかを保存する
     }
     if (draw.includes(judgeValue)) {
         drawer(playerList);

--- a/test/src/judge_UT.js
+++ b/test/src/judge_UT.js
@@ -86,4 +86,30 @@ describe('judgeモジュールのテスト', () => {
             }
         });
     });
+
+    describe('入力されなかったときの負け判定(無条件で未入力の人以外は勝ち)', () => {
+        let playerList = [{ name: 'player1' }, { name: 'player2' }, { name: 'player3' }, { name: 'player4' }];
+        it('未入力の人以外であいこになる場合', () => {
+            playerList[0].hand = 0;
+            playerList[1].hand = 1;
+            playerList[2].hand = 2;
+            playerList[3].hand = -1;
+            playerList = judge(playerList);
+            assert.strictEqual(playerList[0].judge, 1);
+            assert.strictEqual(playerList[1].judge, 1);
+            assert.strictEqual(playerList[2].judge, 1);
+            assert.strictEqual(playerList[3].judge, -1);
+        });
+        it('未入力の人以外で勝敗がつく場合', () => {
+            playerList[0].hand = 0;
+            playerList[1].hand = 2;
+            playerList[2].hand = 2;
+            playerList[3].hand = -1;
+            playerList = judge(playerList);
+            assert.strictEqual(playerList[0].judge, 1);
+            assert.strictEqual(playerList[1].judge, 1);
+            assert.strictEqual(playerList[2].judge, 1);
+            assert.strictEqual(playerList[3].judge, -1);
+        });
+    });
 });


### PR DESCRIPTION
じゃんけんの判定を行うモジュールに、未入力の人がいる場合、その人以外が勝利し、未入力の人が敗北する処理を追加した。
確認を行い、マージする。